### PR TITLE
Sprig boot 2 hystrix.stream

### DIFF
--- a/hystrix/model_test.go
+++ b/hystrix/model_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestUnmarshal(t *testing.T) {
-	for _, f := range []string{"command", "threadpool"} {
+	for _, f := range []string{"command", "threadpool", "ping"} {
 		t.Run(f, func(t *testing.T) {
 			var assert = assert.New(t)
 			bts, err := ioutil.ReadFile(fmt.Sprintf("testdata/%s.json", f))

--- a/hystrix/testdata/ping.json
+++ b/hystrix/testdata/ping.json
@@ -1,0 +1,3 @@
+data: {
+  "type": "ping"
+}

--- a/main.go
+++ b/main.go
@@ -100,6 +100,9 @@ func read(url, cluster string) {
 		if !strings.HasPrefix(line, "data:") {
 			continue
 		}
+		if strings.Contains(line, `{"type":"ping"}`) {
+			continue
+		}
 		report(cluster, line)
 	}
 	log.Warn("stream stop reporting")


### PR DESCRIPTION
Sprig boot 2 hystrix.stream return data:{"type":"ping"} instead of "ping" for boot 1. Provide error "don't know what to do with type 'ping'"